### PR TITLE
Chore: Removing reference to "canvas"

### DIFF
--- a/coding_challenge.md
+++ b/coding_challenge.md
@@ -10,7 +10,7 @@ Because the challenge is open-ended, it's possible to spend a long time on this.
 
 ## The challenge
 
-Your task is to write a React app that allows users to add annotations to arbitrary points on a canvas.
+Your task is to write a React app that allows users to add annotations to arbitrary points on the screen.
 
 ## Prerequisites
 


### PR DESCRIPTION
A lot of candidates have asked questions about whether they should use the `canvas` element or if a `div` is fine. I am trying to remove confusion with this change